### PR TITLE
使用xstring判断数字或字母。

### DIFF
--- a/njuthesis.cls
+++ b/njuthesis.cls
@@ -73,6 +73,7 @@
 \RequirePackage{fancyhdr}
 \RequirePackage{shortvrb}
 \RequirePackage{xltxtra}
+\RequirePackage{xstring}
 \RequirePackage[CJKnumber,CJKchecksingle]{xeCJK}
 \RequirePackage{CJKnumb}
 \defaultfontfeatures{Mapping=tex-text}
@@ -592,7 +593,16 @@
       \penalty\@highpenalty
     \endgroup
   \fi}
-\renewcommand*{\tableofcontents}{%
+\titlecontents{chapter}[0pt]
+    {\addvspace{1.5pt}\filright\bfseries}
+    {
+      \IfInteger{\thecontentslabel}
+        {\contentspush{第\hspace{0.5em}\CJKnumber{\thecontentslabel}\hspace{0.5em}章\quad}}
+        {\contentspush{附录\hspace{1em}\thecontentslabel\quad}}
+    }
+    {}
+    {\titlerule*[5pt]{$\cdot$}\contentspage}
+\renewcommand*{\tableofcontents}{%    
     \if@twocolumn
       \@restonecoltrue\onecolumn
     \else


### PR DESCRIPTION
如果章节号只有数字或者字母两种的话，
可以用xstring判断label是否为数字，来使用不同的标题。

但这样修改后标题会对不齐。。


![6c7c235f3ac2b21a0e3134b50c3a110](https://user-images.githubusercontent.com/7367333/58397958-ad6b3200-8085-11e9-9511-e9270362f2b7.png)
