### PR TITLE
fix \makelicense not showing the title when title has two lines

### DIFF
--- a/njuthesis.cls
+++ b/njuthesis.cls
@@ -1040,7 +1040,7 @@
     {|C{2.2cm}|C{2cm}|C{1.5cm}|C{2.1cm}|C{1.42cm}C{1.5cm}|C{1.25cm}|}
   \hline
   \cell{2.2cm}{1cm}{\njut@cap@license@title}
-  & \multicolumn{6}{c|}{\njut@value@title} \\
+  & \multicolumn{6}{c|}{\ifdefempty{\njut@value@title}{\njut@value@titlea\njut@value@titleb}{\njut@value@title}} \\
   \hline
   \cell{2.2cm}{1cm}{\njut@cap@license@studentnum}
   & {\njut@value@studentnum}


### PR DESCRIPTION
In `njuthesis.cls` file, change (line 1043) `% & \multicolumn{6}{c|}{\njut@value@title} \\` to `& \multicolumn{6}{c|}{\ifdefempty{\njut@value@title}{\njut@value@titlea\njut@value@titleb}{\njut@value@title}} \\` so that it can show title properly when title has two lines.